### PR TITLE
fixing an undefined case

### DIFF
--- a/src/changeset.js
+++ b/src/changeset.js
@@ -118,7 +118,7 @@ export class ChangeSet {
       // Check for adjacent insertions/deletions with compatible data
       // that fully or partially undo each other, and shrink or delete
       // them to clean up the output.
-      if (merge) for (; j < inserted.length; j++) {
+      if (merge) for (; j < inserted.length && j >= 0; j++) {
         let next = inserted[j]
         if (next.from > span.pos) break
         if (next.from < span.pos || !this.config.compare(span.data, next.data)) continue


### PR DESCRIPTION
I'm not sure that I have a clear description of when exactly this bug takes places, because it takes place so deep into the history of documents where we've recorded steps that it's hard to describe exactly what's happening that leads to this, but not infrequently the `let next = inserted[j]` line will be undefined, which leads to error later on within this undo cleanup loop. This fix guards against that. I'm realizing that we actually patched this previously, but didn't do so on the prototype, so it's possible this change got lost in the transition to the public module!

I was trying to take a stab at developing a test case for this (trying to understand the `find` test harness) but in the interest of time, I figured I'd send this patch your way in case the test case would be relatively simple and I'm just missing something!