### PR TITLE
clarifies the position-mapping helper's scope

### DIFF
--- a/test/test-changes.js
+++ b/test/test-changes.js
@@ -6,71 +6,71 @@ const {ChangeSet} = require("..")
 
 describe("ChangeSet", () => {
   it("finds a single insertion",
-     find(doc(p("he<a>llo")), (tr, p) => tr.insert(p("a"), schema.text("XY")), {a: 2}))
+     find(doc(p("he<a>llo")), (tr, pos) => tr.insert(pos("a"), schema.text("XY")), {a: 2}))
 
   it("finds a single deletion",
-     find(doc(p("he<a>ll<b>o")), (tr, p) => tr.delete(p("a"), p("b")), null, {a: "ll"}))
+     find(doc(p("he<a>ll<b>o")), (tr, pos) => tr.delete(pos("a"), pos("b")), null, {a: "ll"}))
 
   it("identifies a replacement",
-     find(doc(p("he<a>ll<b>o")), (tr, p) => tr.replaceWith(p("a"), p("b"), schema.text("juj")), {a: 3}, {a: "ll"}))
+     find(doc(p("he<a>ll<b>o")), (tr, pos) => tr.replaceWith(pos("a"), pos("b"), schema.text("juj")), {a: 3}, {a: "ll"}))
 
   it("merges adjacent canceling edits",
-     find(doc(p("he<a>ll<b>o")), (tr, p) => tr.delete(p("a"), p("b")).insert(p("a"), schema.text("ll"))))
+     find(doc(p("he<a>ll<b>o")), (tr, pos) => tr.delete(pos("a"), pos("b")).insert(pos("a"), schema.text("ll"))))
 
   it("doesn't crash when cancelling edits are followed by others",
-     find(doc(p("h<a>e<b>ll<c>o<d>")), (tr, p) => tr.delete(p("a"), p("b")).insert(p("a"), schema.text("e")).delete(p("c"), p("d")),
+     find(doc(p("h<a>e<b>ll<c>o<d>")), (tr, pos) => tr.delete(pos("a"), pos("b")).insert(pos("a"), schema.text("e")).delete(pos("c"), pos("d")),
           null, {c: "o"}))
 
   it("partially merges insert at start",
-     find(doc(p("he<a>l<b>L<c>o")), (tr, p) => tr.delete(p("a"), p("c")).insert(p("a"), schema.text("l")), null, {4: "L"}))
+     find(doc(p("he<a>l<b>L<c>o")), (tr, pos) => tr.delete(pos("a"), pos("c")).insert(pos("a"), schema.text("l")), null, {4: "L"}))
 
   it("partially merges insert at end",
-     find(doc(p("he<a>lL<b>o")), (tr, p) => tr.delete(p("a"), p("b")).insert(p("a"), schema.text("L")), null, {3: "l"}))
+     find(doc(p("he<a>lL<b>o")), (tr, pos) => tr.delete(pos("a"), pos("b")).insert(pos("a"), schema.text("L")), null, {3: "l"}))
 
   it("partially merges delete at start",
-     find(doc(p("ab<a>c")), (tr, p) => tr.insert(p("a"), schema.text("xyz")).delete(p("a"), p("a") + 1), {a: 2}))
+     find(doc(p("ab<a>c")), (tr, pos) => tr.insert(pos("a"), schema.text("xyz")).delete(pos("a"), pos("a") + 1), {a: 2}))
 
   it("partially merges delete at end",
-     find(doc(p("ab<a>c")), (tr, p) => tr.insert(p("a"), schema.text("xyz")).delete(p("a", 1) - 1, p("a", 1)), {3: 2}))
+     find(doc(p("ab<a>c")), (tr, pos) => tr.insert(pos("a"), schema.text("xyz")).delete(pos("a", 1) - 1, pos("a", 1)), {3: 2}))
 
   it("finds multiple insertions",
-     find(doc(p("<a>abc<b>")), (tr, p) => tr.insert(p("a"), schema.text("x")).insert(p("b"), schema.text("y")), {a: 1, b: 1}))
+     find(doc(p("<a>abc<b>")), (tr, pos) => tr.insert(pos("a"), schema.text("x")).insert(pos("b"), schema.text("y")), {a: 1, b: 1}))
 
   it("finds multiple deletions",
-     find(doc(p("<a>x<b>y<c>z<d>")), (tr, p) => tr.delete(p("a"), p("b")).delete(p("c"), p("d")), null, {a: "x", c: "z"}))
+     find(doc(p("<a>x<b>y<c>z<d>")), (tr, pos) => tr.delete(pos("a"), pos("b")).delete(pos("c"), pos("d")), null, {a: "x", c: "z"}))
 
   it("identifies a deletion between insertions",
-     find(doc(p("z<a>y<b>z")), (tr, p) => tr.insert(p("a"), schema.text("A")).insert(p("b"), schema.text("B")).delete(p("a", 1), p("b")),
+     find(doc(p("z<a>y<b>z")), (tr, pos) => tr.insert(pos("a"), schema.text("A")).insert(pos("b"), schema.text("B")).delete(pos("a", 1), pos("b")),
           {a: 2}, {a: "y"}))
 
   it("can add a deletion in a new addStep call", find(doc(p("h<a>e<b>l<c>l<d>o")), [
-    (tr, p) => tr.delete(p("a"), p("b")),
-    (tr, p) => tr.delete(p("c"), p("d"))
+    (tr, pos) => tr.delete(pos("a"), pos("b")),
+    (tr, pos) => tr.delete(pos("c"), pos("d"))
   ], null, {a: "e", c: "l"}))
 
   it("merges delete/insert from different addStep calls", find(doc(p("he<a>ll<b>o")), [
-    (tr, p) => tr.delete(p("a"), p("b")),
-    (tr, p) => tr.insert(p("a"), schema.text("ll"))
+    (tr, pos) => tr.delete(pos("a"), pos("b")),
+    (tr, pos) => tr.insert(pos("a"), schema.text("ll"))
   ]))
 
   it("partially merges delete/insert from different addStep calls", find(doc(p("he<a>lj<b>o")), [
-    (tr, p) => tr.delete(p("a"), p("b")),
-    (tr, p) => tr.insert(p("a"), schema.text("ll"))
+    (tr, pos) => tr.delete(pos("a"), pos("b")),
+    (tr, pos) => tr.insert(pos("a"), schema.text("ll"))
   ], {4: 1}, {4: "j"}))
 
   it("merges insert/delete from different addStep calls", find(doc(p("o<a>k")), [
-    (tr, p) => tr.insert(p("a"), schema.text("--")),
-    (tr, p) => tr.delete(p("a"), p("a", 1))
+    (tr, pos) => tr.insert(pos("a"), schema.text("--")),
+    (tr, pos) => tr.delete(pos("a"), pos("a", 1))
   ]))
 
   it("partially merges insert/delete from different addStep calls", find(doc(p("o<a>k")), [
-    (tr, p) => tr.insert(p("a"), schema.text("--")),
-    (tr, p) => tr.delete(p("a"), p("a") + 1)
+    (tr, pos) => tr.insert(pos("a"), schema.text("--")),
+    (tr, pos) => tr.delete(pos("a"), pos("a") + 1)
   ], {a: 1}))
 
   it("maps deletions forward", find(doc(p("f<a>ooba<b>r<c>")), [
-    (tr, p) => tr.delete(p("b"), p("c")),
-    (tr, p) => tr.insert(p("a"), schema.text("OKAY"))
+    (tr, pos) => tr.delete(pos("b"), pos("c")),
+    (tr, pos) => tr.insert(pos("a"), schema.text("OKAY"))
   ], {a: 4}, {b: "r"}))
 })
 


### PR DESCRIPTION
After spending some time this morning wrapping my head around these tests, I realized my eyes were getting confused by the anonymous functions' `p` not being the same as the `prosemirror-test-helper`'s `p`! This is a nice-to-have patch that makes it a little easier to understand what's going on in these tests.