### PR TITLE
Insertion before change

### DIFF
--- a/src/change.js
+++ b/src/change.js
@@ -112,6 +112,10 @@ export class Change {
         let fromA = Math.min(curX.fromA, curY.fromA - (iX ? x[iX - 1].toB - x[iX - 1].toA : 0)), toA = fromA
         let fromB = Math.min(curY.fromB, curX.fromB + (iY ? y[iY - 1].toB - y[iY - 1].toA : 0)), toB = fromB
         let deleted = Span.none, inserted = Span.none
+
+        // Used to prevent appending ins/del range for the same Change twice
+        let enteredX = false, enteredY = false
+
         // Need to have an inner loop since any number of further
         // ranges might be touching this group
         for (;;) {
@@ -120,24 +124,33 @@ export class Change {
           let next = Math.min(nextX, nextY)
           let inX = curX && pos >= curX.fromB, inY = curY && pos >= curY.fromA
           if (!inX && !inY) break
-          if (inX && pos == curX.fromB && (next != curX.fromB || next == curX.toB)) {
+          if (inX && pos == curX.fromB && !enteredX) {
             deleted = Span.join(deleted, curX.deleted, combine)
             toA += curX.lenA
+            enteredX = true
           }
           if (inX && !inY) {
             inserted = Span.join(inserted, Span.slice(curX.inserted, pos - curX.fromB, next - curX.fromB), combine)
             toB += next - pos
           }
-          if (inY && pos == curY.fromA) {
+          if (inY && pos == curY.fromA && !enteredY) {
             inserted = Span.join(inserted, curY.inserted, combine)
             toB += curY.lenB
+            enteredY = true
           }
           if (inY && !inX) {
             deleted = Span.join(deleted, Span.slice(curY.deleted, pos - curY.fromA, next - curY.fromA), combine)
             toA += next - pos
           }
-          if (inX && next == curX.toB) curX = iX++ == x.length ? null : x[iX]
-          if (inY && next == curY.toA) curY = iY++ == y.length ? null : y[iY]
+
+          if (inX && next == curX.toB) {
+            curX = iX++ == x.length ? null : x[iX]
+            enteredX = false
+          }
+          if (inY && next == curY.toA) {
+            curY = iY++ == y.length ? null : y[iY]
+            enteredY = false
+          }
           pos = next
         }
         if (fromA < toA || fromB < toB)

--- a/src/change.js
+++ b/src/change.js
@@ -120,7 +120,7 @@ export class Change {
           let next = Math.min(nextX, nextY)
           let inX = curX && pos >= curX.fromB, inY = curY && pos >= curY.fromA
           if (!inX && !inY) break
-          if (inX && pos == curX.fromB) {
+          if (inX && pos == curX.fromB && (next != curX.fromB || next == curX.toB)) {
             deleted = Span.join(deleted, curX.deleted, combine)
             toA += curX.lenA
           }

--- a/test/test-changes.js
+++ b/test/test-changes.js
@@ -67,6 +67,18 @@ describe("ChangeSet", () => {
     tr => tr.insert(3, t("ll"))
   ], []))
 
+  it("revert a deletion by inserting the character again", find(doc(p("bar")), [
+    tr => tr.delete(2, 3), // br
+    tr => tr.insert(2, t("x")), // bxr
+    tr => tr.insert(2, t("a")) // baxr
+  ], [[3, 3, 3, 4]]))
+
+  it("insert character before changed character", find(doc(p("bar")), [
+    tr => tr.delete(2, 3), // br
+    tr => tr.insert(2, t("x")), // bxr
+    tr => tr.insert(2, t("x")) // bxxr
+  ], [[2, 3, 2, 4]]))
+
   it("partially merges delete/insert from different addStep calls", find(doc(p("heljo")), [
     tr => tr.delete(3, 5),
     tr => tr.insert(3, t("ll"))

--- a/test/test-changes.js
+++ b/test/test-changes.js
@@ -164,7 +164,7 @@ describe("ChangeSet", () => {
     tr => tr.replaceWith(1, 1, t("eAUDOMIKkMf")),
     tr => tr.delete(5, 8),
     tr => tr.replaceWith(3, 3, t("qX"))
-  ], [[3, 12, 3, 10, [[2, 0], [5, 2], [2, 0]], [[7, 0]]]], [2, 0, 0, 0, 0, 0, 0]))
+  ], [[3, 10, 3, 10, [[2, 0], [5, 2]], [[7, 0]]]], [2, 0, 0, 0, 0, 0, 0]))
 
   it("fuzz issue 3", find(doc(p("hfxjahnOuH")), [
     tr => tr.delete(1, 5),

--- a/test/test-merge.js
+++ b/test/test-merge.js
@@ -1,0 +1,58 @@
+const ist = require("ist")
+const {doc, p, img} = require("prosemirror-test-builder")
+const {Change, Span} = require("..")
+
+describe("mergeChanges", () => {
+  it("can merge simple insertions", () => test(
+    [[1, 1, 1, 2]], [[1, 1, 1, 2]], [[1, 1, 1, 3]]
+  ))
+
+  it("can merge simple deletions", () => test(
+    [[1, 2, 1, 1]], [[1, 2, 1, 1]], [[1, 3, 1, 1]]
+  ))
+
+  it("can merge insertion before deletion", () => test(
+    [[2, 3, 2, 2]], [[1, 1, 1, 2]], [[1, 1, 1, 2], [2, 3, 3, 3]]
+  ))
+
+  it("can merge insertion after deletion", () => test(
+    [[2, 3, 2, 2]], [[2, 2, 2, 3]], [[2, 3, 2, 3]]
+  ))
+
+  it("can merge deletion before insertion", () => test(
+    [[2, 2, 2, 3]], [[1, 2, 1, 1]], [[1, 2, 1, 2]]
+  ))
+
+  it("can merge deletion after insertion", () => test(
+    [[2, 2, 2, 3]], [[3, 4, 3, 3]], [[2, 3, 2, 3]]
+  ))
+
+  it("can merge deletion of insertion", () => test(
+    [[2, 2, 2, 3]], [[2, 3, 2, 2]], []
+  ))
+
+  it("can merge insertion after replace", () => test(
+    [[2, 3, 2, 3]], [[3, 3, 3, 4]], [[2, 3, 2, 4]]
+  ))
+
+  it("can merge insertion before replace", () => test(
+    [[2, 3, 2, 3]], [[2, 2, 2, 3]], [[2, 3, 2, 4]]
+  ))
+
+  it("can merge replace after insert", () => test(
+    [[2, 2, 2, 3]], [[2, 3, 2, 3]], [[2, 2, 2, 3]]
+  ))
+
+})
+
+function range(array, author = 0) {
+  let [fromA, toA] = array
+  let [fromB, toB] = array.length > 2 ? array.slice(2) : array
+  return new Change(fromA, toA, fromB, toB, [new Span(toA - fromA, author)], [new Span(toB - fromB, author)])
+}
+
+function test(changeA, changeB, expected) {
+  const result = Change.merge(changeA.map(range), changeB.map(range), a => a)
+    .map(r => [r.fromA, r.toA, r.fromB, r.toB])
+  ist(JSON.stringify(result), JSON.stringify(expected))
+}


### PR DESCRIPTION
As described in https://github.com/ProseMirror/prosemirror-changeset/issues/6

Fixes an insertion before a change:
```
ab|c                                  []
<delete b>       + [2, 3, 2, 2]
a|c                                   = [2, 3, 2, 2]
<insert x>       + [2, 2, 2, 3]
ax|c                                  = [2, 3, 2, 3]
<move left>      + []
a|xc                                  = [2, 3, 2, 3]
<insert x>       + [2, 2, 2, 3]
ax|xc                                 = [2, 4, 2, 4] (old, incorrect) [2, 3, 2, 4] (new, correct)
```