### PR TITLE
Compare `curX` when checking if `curY` lies entirely before `curX`.

### DIFF
--- a/src/change.js
+++ b/src/change.js
@@ -96,7 +96,7 @@ export class Change {
                     new Change(curX.fromA, curX.toA, curX.fromB + off, curX.toB + off,
                                curX.deleted, curX.inserted))
         curX = iX++ == x.length ? null : x[iX]
-      } else if (curY && (!curX || curY.toA < curY.fromB)) { // curY entirely in front of curX
+      } else if (curY && (!curX || curY.toA < curX.fromB)) { // curY entirely in front of curX
         let off = iX ? x[iX - 1].toB - x[iX - 1].toA : 0
         result.push(off == 0 ? curY :
                     new Change(curY.fromA - off, curY.toA - off, curY.fromB, curY.toB,


### PR DESCRIPTION
Fixes (probably) a typo when checking if `curY` lies entirely before `curX`. As discussed here: https://github.com/ProseMirror/prosemirror-changeset/issues/6#issuecomment-471536878