### PR TITLE
Support tracking changes in marks and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This encoder ignores marks and attributes. This is the default encoder when crea
 ### class MarkEncoder
 
 Encoder that considers node types, character codes, and mark names.
-This encoder ignores mark an node attributes.
+This encoder ignores mark and node attributes.
 
 
 ### class AttributeEncoder

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ An interface for encoding document nodes and characters into tokens for diffing.
 ### class BaseEncoder
 
 Base encoder that only considers node types and character codes.
-This encoder ignores marks and attributes. This is the default encoder when creating a `ChangeSet` class
+This encoder ignores marks and attributes. This is the default encoder when creating a `ChangeSet` class.
 
 
 ### class MarkEncoder

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ partially undo themselves by comparing their content.
 
  * **`constructor`**`: (config: {doc: Node, combine: fn(dataA: Data, dataB: Data) → Data, tokenEncoder?: TokenEncoder}, changes: readonly Change[]) => ChangeSet`: Create a changeset with the given base object and configuration.
    The `combine` function is used to compare and combine metadata—it
-   should return null when metadata isn't compatible, and a combined
+   should return `null` when metadata isn't compatible, and a combined
    version for a merged range when it is. The `tokenEncoder` is used to determine how document nodes and characters
    are encoded for comparison during diffing. If not provided, the default `BaseEncoder` is used.
 
@@ -102,11 +102,11 @@ partially undo themselves by comparing their content.
    make sure the method is called on the old set and passed the new
    set. The returned positions will be in new document coordinates.
 
- * `static `**`create`**`<Data = any>(doc: Node, combine?: fn(dataA: Data, dataB: Data) → Data = (a, b) => a === b ? a : null as any, tokenEncoder?: TokenEncoder) → ChangeSet`\
-  Create a changeset with the given base object and configuration.
-  The `combine` function is used to compare and combine metadata—it
-  should return `nul`l` when metadata isn't compatible, and a combined
-  version for a merged range when it is.
+ * `static `**`create`**`<Data = any>(doc: Node, combine?: fn(dataA: Data, dataB: Data) → Data = (a, b) => a === b ? a : `null` as any, tokenEncoder?: TokenEncoder) → ChangeSet`\
+   Create a changeset with the given base object and configuration.
+   The `combine` function is used to compare and combine metadata—it
+   should return `null` when metadata isn't compatible, and a combined
+   version for a merged range when it is.
 
 
  * **`simplifyChanges`**`(changes: readonly Change[], doc: Node) → Change[]`\

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ in the past. It condenses a number of step maps down to a flat
 sequence of replacements, and simplifies replacments that
 partially undo themselves by comparing their content.
 
+ * **`constructor`**`: (config: {doc: Node, combine: fn(dataA: Data, dataB: Data) → Data, tokenEncoder?: TokenEncoder}, changes: readonly Change[]) => ChangeSet`: Create a changeset with the given base object and configuration.
+   The `combine` function is used to compare and combine metadata—it
+   should return null when metadata isn't compatible, and a combined
+   version for a merged range when it is. The `tokenEncoder` is used to determine how document nodes and characters
+   are encoded for comparison during diffing. If not provided, the default `BaseEncoder` is used.
+
  * **`changes`**`: readonly Change[]`\
    Replaced regions.
 
@@ -96,11 +102,11 @@ partially undo themselves by comparing their content.
    make sure the method is called on the old set and passed the new
    set. The returned positions will be in new document coordinates.
 
- * `static `**`create`**`<Data = any>(doc: Node, combine?: fn(dataA: Data, dataB: Data) → Data = (a, b) => a === b ? a : null as any) → ChangeSet`\
-   Create a changeset with the given base object and configuration.
-   The `combine` function is used to compare and combine metadata—it
-   should return null when metadata isn't compatible, and a combined
-   version for a merged range when it is.
+ * `static `**`create`**`<Data = any>(doc: Node, combine?: fn(dataA: Data, dataB: Data) → Data = (a, b) => a === b ? a : null as any, tokenEncoder?: TokenEncoder) → ChangeSet`\
+  Create a changeset with the given base object and configuration.
+  The `combine` function is used to compare and combine metadata—it
+  should return `nul`l` when metadata isn't compatible, and a combined
+  version for a merged range when it is.
 
 
  * **`simplifyChanges`**`(changes: readonly Change[], doc: Node) → Change[]`\
@@ -111,3 +117,31 @@ partially undo themselves by comparing their content.
    words (in the new document) they touch. An exception is made for
    single-character replacements.
 
+
+### interface TokenEncoder
+
+An interface for encoding document nodes and characters into tokens for diffing.
+
+ * **`encodeCharacter`**`(char: number, node: Node) → string | number`\
+   Encodes a character from a text node into a token.
+
+ * **`encodeNode`**`(node: Node) → string`\
+   Encodes a node into a token.
+
+
+### class BaseEncoder
+
+Base encoder that only considers node types and character codes.
+This encoder ignores marks and attributes. This is the default encoder when creating a `ChangeSet` class
+
+
+### class MarkEncoder
+
+Encoder that considers node types, character codes, and mark names.
+This encoder ignores mark an node attributes.
+
+
+### class AttributeEncoder
+
+Encoder that considers node types, character codes, mark names, and all attributes.
+This is the most detailed encoder, but also the least performant.

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -74,16 +74,6 @@ export function computeDiff(
   if (start == tokA.length && start == tokB.length) return []
   while (endA > start && endB > start && tokA[endA - 1] === tokB[endB - 1]) endA--, endB--
 
-  // Special case for node type changes - if we have different node types at the start
-  if (
-    start === 0 &&
-    typeof tokA[0] === "string" &&
-    typeof tokB[0] === "string" &&
-    tokA[0] !== tokB[0]
-  ) {
-    return [range.slice(0, endA, 0, endB)];
-  }
-
   // If the result is simple _or_ too big to cheaply compute, return
   // the remaining region as the diff
   if (endA == start || endB == start || (endA == endB && endA == start + 1))

--- a/src/token-encoder.ts
+++ b/src/token-encoder.ts
@@ -39,13 +39,6 @@ export class BaseEncoder implements TokenEncoder {
  * This encoder ignores node and mark attributes.
  */
 export class MarkEncoder implements TokenEncoder {
-  private encodeMarks(marks: readonly Mark[]): string {
-    return marks
-      .map((m) => m.type.name)
-      .sort()
-      .join(",");
-  }
-
   encodeCharacter(char: number, node: Node): string | number {
     const marks = node.marks;
     if (!marks.length) return char;
@@ -61,6 +54,13 @@ export class MarkEncoder implements TokenEncoder {
 
     return `${nodeName}:${this.encodeMarks(marks)}`;
   }
+
+  private encodeMarks(marks: readonly Mark[]): string {
+    return marks
+      .map((m) => m.type.name)
+      .sort()
+      .join(",");
+  }
 }
 
 /**
@@ -72,18 +72,7 @@ export class AttributeEncoder implements TokenEncoder {
     const marks = node.marks;
     if (!marks.length) return char;
 
-    const markStr = marks
-      .map((m) => {
-        let result = m.type.name;
-        if (Object.keys(m.attrs).length) {
-          result += ":" + JSON.stringify(m.attrs);
-        }
-        return result;
-      })
-      .sort()
-      .join(",");
-
-    return `${char}:${markStr}`;
+    return `${char}:${this.encodeMarks(marks)}`;
   }
 
   encodeNode(node: Node): string {
@@ -98,7 +87,11 @@ export class AttributeEncoder implements TokenEncoder {
 
     if (!marks.length) return nodeStr;
 
-    const markStr = marks
+    return `${nodeStr}:${this.encodeMarks(marks)}`;
+  }
+
+  private encodeMarks(marks: readonly Mark[]): string {
+    return marks
       .map((m) => {
         let result = m.type.name;
         if (Object.keys(m.attrs).length) {
@@ -108,7 +101,5 @@ export class AttributeEncoder implements TokenEncoder {
       })
       .sort()
       .join(",");
-
-    return `${nodeStr}:${markStr}`;
   }
 }

--- a/src/token-encoder.ts
+++ b/src/token-encoder.ts
@@ -1,0 +1,114 @@
+import { Node, Mark } from "prosemirror-model";
+
+/**
+ * Interface for encoding document nodes and characters into tokens for diffing.
+ */
+export interface TokenEncoder {
+  /**
+   * Encodes a character from a text node into a token.
+   * @param char The character code
+   * @param node The text node containing the character
+   * @returns A string or number representing the token
+   */
+  encodeCharacter(char: number, node: Node): string | number;
+
+  /**
+   * Encodes a node into a token.
+   * @param node The node to encode
+   * @returns A string representing the token
+   */
+  encodeNode(node: Node): string;
+}
+
+/**
+ * Base encoder that only considers node types and character codes.
+ * This encoder ignores marks and node attributes. This is the default encoder when creating a `ChangeSet` class.
+ */
+export class BaseEncoder implements TokenEncoder {
+  encodeCharacter(char: number, _node: Node): number {
+    return char;
+  }
+
+  encodeNode(node: Node): string {
+    return node.type.name;
+  }
+}
+
+/**
+ * Encoder that considers node types, character codes, and mark names.
+ * This encoder ignores node and mark attributes.
+ */
+export class MarkEncoder implements TokenEncoder {
+  private encodeMarks(marks: readonly Mark[]): string {
+    return marks
+      .map((m) => m.type.name)
+      .sort()
+      .join(",");
+  }
+
+  encodeCharacter(char: number, node: Node): string | number {
+    const marks = node.marks;
+    if (!marks.length) return char;
+
+    return `${char}:${this.encodeMarks(marks)}`;
+  }
+
+  encodeNode(node: Node): string {
+    const nodeName = node.type.name;
+    const marks = node.marks;
+
+    if (!marks.length) return nodeName;
+
+    return `${nodeName}:${this.encodeMarks(marks)}`;
+  }
+}
+
+/**
+ * Encoder that considers node types, character codes, mark names, and all attributes.
+ * This is the most detailed encoder but also the least performant.
+ */
+export class AttributeEncoder implements TokenEncoder {
+  encodeCharacter(char: number, node: Node): string | number {
+    const marks = node.marks;
+    if (!marks.length) return char;
+
+    const markStr = marks
+      .map((m) => {
+        let result = m.type.name;
+        if (Object.keys(m.attrs).length) {
+          result += ":" + JSON.stringify(m.attrs);
+        }
+        return result;
+      })
+      .sort()
+      .join(",");
+
+    return `${char}:${markStr}`;
+  }
+
+  encodeNode(node: Node): string {
+    const nodeName = node.type.name;
+    const marks = node.marks;
+
+    // Add node attributes if they exist
+    let nodeStr = nodeName;
+    if (Object.keys(node.attrs).length) {
+      nodeStr += ":" + JSON.stringify(node.attrs);
+    }
+
+    if (!marks.length) return nodeStr;
+
+    const markStr = marks
+      .map((m) => {
+        let result = m.type.name;
+        if (Object.keys(m.attrs).length) {
+          result += ":" + JSON.stringify(m.attrs);
+        }
+        return result;
+      })
+      .sort()
+      .join(",");
+
+    return `${nodeStr}:${markStr}`;
+  }
+}

--- a/test/test-diff.ts
+++ b/test/test-diff.ts
@@ -1,7 +1,7 @@
 import ist from "ist"
 import {doc, p, em, strong, h1, h2} from "prosemirror-test-builder"
 import {Node} from "prosemirror-model"
-import {Span, Change, ChangeSet} from "prosemirror-changeset"
+import {Span, Change, ChangeSet, BaseEncoder} from "prosemirror-changeset"
 const {computeDiff} = ChangeSet
 
 describe("computeDiff", () => {
@@ -9,7 +9,8 @@ describe("computeDiff", () => {
     let diff = computeDiff(doc1.content, doc2.content,
                            new Change(0, doc1.content.size, 0, doc2.content.size,
                                       [new Span(doc1.content.size, 0)],
-                                      [new Span(doc2.content.size, 0)]))
+                                      [new Span(doc2.content.size, 0)]), 
+                                      new BaseEncoder())
     ist(JSON.stringify(diff.map(r => [r.fromA, r.toA, r.fromB, r.toB])), JSON.stringify(ranges))
   }
 
@@ -39,20 +40,12 @@ describe("computeDiff", () => {
      test(doc(p("abc"), p("def")), doc(p("ac"), p("d")),
           [2, 3, 2, 2], [7, 9, 6, 6]))
 
-  it("detects marks", () =>
-    test(doc(p("abc")), doc(p(em("a"), strong("bc"))), [1, 4, 1, 4]));
+  it("ignores marks", () =>
+     test(doc(p("abc")), doc(p(em("a"), strong("bc")))))
 
-  it("detects marks in diffing", () =>
-    test(
-      doc(p("abcdefghi")),
-      doc(p(em("a"), strong("bc"), "defgh", em("i"))),
-      [1, 4, 1, 4],
-      [9, 10, 9, 10]
-    ));
-
-  it("detects mark changes without text changes", () =>
-    test(doc(p("abc")), doc(p("a", em("b"), "c")), [2, 3, 2, 3]));
-
+  it("ignores marks in diffing", () =>
+     test(doc(p("abcdefghi")), doc(p(em("x"), strong("bc"), "defgh", em("y"))),
+          [1, 2, 1, 2], [9, 10, 9, 10]))
 
   it("ignores attributes", () =>
      test(doc(h1("x")), doc(h2("x"))))

--- a/test/test-diff.ts
+++ b/test/test-diff.ts
@@ -39,12 +39,20 @@ describe("computeDiff", () => {
      test(doc(p("abc"), p("def")), doc(p("ac"), p("d")),
           [2, 3, 2, 2], [7, 9, 6, 6]))
 
-  it("ignores marks", () =>
-     test(doc(p("abc")), doc(p(em("a"), strong("bc")))))
+  it("detects marks", () =>
+    test(doc(p("abc")), doc(p(em("a"), strong("bc"))), [1, 4, 1, 4]));
 
-  it("ignores marks in diffing", () =>
-     test(doc(p("abcdefghi")), doc(p(em("x"), strong("bc"), "defgh", em("y"))),
-          [1, 2, 1, 2], [9, 10, 9, 10]))
+  it("detects marks in diffing", () =>
+    test(
+      doc(p("abcdefghi")),
+      doc(p(em("a"), strong("bc"), "defgh", em("i"))),
+      [1, 4, 1, 4],
+      [9, 10, 9, 10]
+    ));
+
+  it("detects mark changes without text changes", () =>
+    test(doc(p("abc")), doc(p("a", em("b"), "c")), [2, 3, 2, 3]));
+
 
   it("ignores attributes", () =>
      test(doc(h1("x")), doc(h2("x"))))


### PR DESCRIPTION
This PR adds an option to configure the `ChangeSet` class so that it can find changes in marks and attributes, as well as in nodes.

# Approach

Adds a `tokenEncoder` configuration option to the `ChangeSet` class. It accepts a `TokenEncoder` object, which lets developers customize how characters and nodes are encoded for diffing. This lets the developer find changes not only in nodes and content, but also in marks and attributes of their choice.

Adds 3 built-in `TokenEncoder` objects:

- `BaseEncoder` (default): only encodes the character and node type info inside tokens. Is the equivalent to using the ChangeSet class before this PR.
- `MarkEncoder`: encodes the mark data inside tokens.
- `AttributeEncoder`: encodes the data of marks and attributes inside tokens.

# Breaking changes

There are no breaking changes. The default behavior of the `ChangeSet` class is still the same. It only adds the `tokenEncoder` configuration options

# Changes

- Added the configuration option to the `ChangeSet` class.
- Modified the `tokens` function so that it supports custom token encoders.
- Updated the docs

# Motivation for this change

At [Tiptap](https://tiptap.dev/), we're building tools to help track the changes made by multiple users in the same document. Some changes might involve only modifying a mark of the document (like, setting a word from normal to bold). We want to be able to detect these changes with the prosemirror-changeset library.

We're also building workflows where [an AI assistant edits the document](https://tiptap.dev/docs/content-ai/capabilities/changes/overview), and the user reviews the changes it made. We want to be able to detect changes in formatting made by the AI, and show them to the user in a diff format.

---

Please let us know what you think of the approach we took in solving the problem, and if you'd recommend us to solve it in another way. Also let us know if there are any issues in formatting/tests/docs that we should fix. Thanks for reviewing 😄 .

Closes #4 

