### PR TITLE
Add a static fromChanges method to ChangeSet class

### DIFF
--- a/src/changeset.ts
+++ b/src/changeset.ts
@@ -154,6 +154,20 @@ export class ChangeSet<Data = any> {
     return new ChangeSet({combine, doc, encoder: tokenEncoder}, [])
   }
 
+  /// Create a changeset from a set of changes, using the given configuration.
+  static fromChanges<Data = any>(
+    doc: Node, 
+    changes: Change<Data>[], 
+    combine?: (dataA: Data, dataB: Data) => Data, 
+    encoder?: TokenEncoder<any>
+  ) {
+    return new ChangeSet({
+      doc: doc,
+      combine: combine ?? ((a, b) => a === b ? a : null as any),
+      encoder: encoder ?? DefaultEncoder
+    }, changes)
+  }
+
   /// Exported for testing @internal
   static computeDiff = computeDiff
 }


### PR DESCRIPTION
If we want to create a ChangeSet from a deserialized Change list we need to have a way to pass the changes to the constructor. 

Currently the constructor is marked @internal So adding this method.